### PR TITLE
feat: Refactor Windows Admin runner to run embedded script file

### DIFF
--- a/src/deadline_worker_agent/startup/entrypoint.py
+++ b/src/deadline_worker_agent/startup/entrypoint.py
@@ -15,6 +15,8 @@ from threading import Event
 from typing import Optional
 from pathlib import Path
 
+from ..aws_credentials.worker_boto3_session import WorkerBoto3Session
+
 from ..feature_flag import HOST_CONFIGURATION_FEATURE
 
 from ..api_models import WorkerStatus
@@ -40,7 +42,7 @@ from ..log_messages import (
 from ..log_sync.cloudwatch import stream_cloudwatch_logs
 from ..log_sync.loggers import ROOT_LOGGER, logger as log_sync_logger
 from ..worker import Worker
-from .bootstrap import bootstrap_worker
+from .bootstrap import WorkerBootstrap, bootstrap_worker
 from .host_configuration_script import HostConfigurationScriptRunner
 
 __all__ = ["entrypoint"]
@@ -168,77 +170,13 @@ def entrypoint(cli_args: Optional[list[str]] = None, *, stop: Optional[Event] = 
             # logs that we forward to CloudWatch.
             _log_agent_info()
 
-            # If there was a host config, and it was bootstrapped before, only log a message.
-            if worker_bootstrap.host_config and not HOST_CONFIGURATION_FEATURE:
-                _logger.info(
-                    WorkerHostConfigurationLogEvent(
-                        farm_id=config.farm_id,
-                        fleet_id=config.fleet_id,
-                        worker_id=worker_id,
-                        message="Host Configuration Feature is not enabled.",
-                        status=WorkerHostConfigurationStatus.SKIPPED,
-                    )
-                )
-            elif (
-                worker_bootstrap.host_config
-                and worker_bootstrap.worker_info.host_configuration_succeeded
-            ):
-                _logger.info(
-                    WorkerHostConfigurationLogEvent(
-                        farm_id=config.farm_id,
-                        fleet_id=config.fleet_id,
-                        worker_id=worker_id,
-                        message="Host Configuration has been setup before. Not running config scripts.",
-                        status=WorkerHostConfigurationStatus.SKIPPED,
-                    )
-                )
-            # Before the run looop starts, run the Host Configuration script.
-            elif worker_bootstrap.host_config:
-                _logger.info(
-                    WorkerHostConfigurationLogEvent(
-                        farm_id=config.farm_id,
-                        fleet_id=config.fleet_id,
-                        worker_id=worker_id,
-                        message="Running host configuration script.",
-                        status=WorkerHostConfigurationStatus.RUNNING,
-                    )
-                )
-                host_config_runner = HostConfigurationScriptRunner(
-                    logger=_logger,
-                    configuration=config,
-                    worker_id=worker_id,
-                    session_directory=config.worker_persistence_dir,
-                    worker_boto3_session=session,
-                    host_configuration_script=worker_bootstrap.host_config.script_body,
-                    host_configuration_timeout_seconds=worker_bootstrap.host_config.script_timeout_seconds,
-                )
-                exit_code = host_config_runner.run()
-                if exit_code == 0:
-                    _logger.info(
-                        WorkerHostConfigurationLogEvent(
-                            farm_id=config.farm_id,
-                            fleet_id=config.fleet_id,
-                            worker_id=worker_id,
-                            message="Worker Agent host configuration succeeded. Starting worker session loop.",
-                            status=WorkerHostConfigurationStatus.SUCCEEDED,
-                            exit_code=exit_code,
-                        )
-                    )
-                    # Persist host configuration has been performed.
-                    worker_bootstrap.worker_info.host_configuration_succeeded = True
-                    worker_bootstrap.worker_info.save(config=config)
-                else:
-                    _logger.critical(
-                        WorkerHostConfigurationLogEvent(
-                            farm_id=config.farm_id,
-                            fleet_id=config.fleet_id,
-                            worker_id=worker_id,
-                            message=f"Worker Agent host configuration failed with exit code {exit_code}. Cannot run jobs, exiting.",
-                            status=WorkerHostConfigurationStatus.FAILED,
-                            exit_code=exit_code,
-                        )
-                    )
-                    sys.exit(1)
+            # Run Worker Host Configuration.
+            _host_configuration(
+                config=config,
+                worker_bootstrap=worker_bootstrap,
+                worker_id=worker_id,
+                session=session,
+            )
 
             worker_sessions = Worker(
                 farm_id=config.farm_id,
@@ -491,6 +429,91 @@ def _configure_base_logging(
     rotating_file_handler.addFilter(translation_filter)
 
     return bootstrapping_handler
+
+
+def _host_configuration(
+    worker_bootstrap: WorkerBootstrap,
+    config: Configuration,
+    worker_id: str,
+    session: WorkerBoto3Session,
+) -> None:
+    """
+    Runs all business logic related to Host Configuration.
+    This method must be run within a cloudwatch stream context to stream logs.
+    If the host configuration run fails, the worker agent exits.
+    """
+
+    # If there was a host config, and it was bootstrapped before, only log a message.
+    if worker_bootstrap.host_config and not HOST_CONFIGURATION_FEATURE:
+        _logger.info(
+            WorkerHostConfigurationLogEvent(
+                farm_id=config.farm_id,
+                fleet_id=config.fleet_id,
+                worker_id=worker_id,
+                message="Host Configuration Feature is not enabled.",
+                status=WorkerHostConfigurationStatus.SKIPPED,
+            )
+        )
+        return
+    elif worker_bootstrap.host_config and worker_bootstrap.worker_info.host_configuration_succeeded:
+        _logger.info(
+            WorkerHostConfigurationLogEvent(
+                farm_id=config.farm_id,
+                fleet_id=config.fleet_id,
+                worker_id=worker_id,
+                message="Host Configuration has been setup before. Not running config scripts.",
+                status=WorkerHostConfigurationStatus.SKIPPED,
+            )
+        )
+        return
+    # Before the run loop starts, run the Host Configuration script.
+    elif worker_bootstrap.host_config:
+        _logger.info(
+            WorkerHostConfigurationLogEvent(
+                farm_id=config.farm_id,
+                fleet_id=config.fleet_id,
+                worker_id=worker_id,
+                message="Running host configuration script.",
+                status=WorkerHostConfigurationStatus.RUNNING,
+            )
+        )
+        host_config_runner = HostConfigurationScriptRunner(
+            logger=_logger,
+            configuration=config,
+            worker_id=worker_id,
+            session_directory=config.worker_persistence_dir,
+            worker_boto3_session=session,
+            host_configuration_script=worker_bootstrap.host_config.script_body,
+            host_configuration_timeout_seconds=worker_bootstrap.host_config.script_timeout_seconds,
+        )
+        exit_code = host_config_runner.run()
+        if exit_code == 0:
+            _logger.info(
+                WorkerHostConfigurationLogEvent(
+                    farm_id=config.farm_id,
+                    fleet_id=config.fleet_id,
+                    worker_id=worker_id,
+                    message="Worker Agent host configuration succeeded. Starting worker session loop.",
+                    status=WorkerHostConfigurationStatus.SUCCEEDED,
+                    exit_code=exit_code,
+                )
+            )
+            # Persist host configuration has been performed.
+            worker_bootstrap.worker_info.host_configuration_succeeded = True
+            worker_bootstrap.worker_info.save(config=config)
+            return
+        else:
+            _logger.critical(
+                WorkerHostConfigurationLogEvent(
+                    farm_id=config.farm_id,
+                    fleet_id=config.fleet_id,
+                    worker_id=worker_id,
+                    message=f"Worker Agent host configuration failed with exit code {exit_code}. Cannot run jobs, exiting.",
+                    status=WorkerHostConfigurationStatus.FAILED,
+                    exit_code=exit_code,
+                )
+            )
+            sys.exit(1)
 
 
 def _remove_logging_handler(handler: logging.Handler) -> None:

--- a/src/deadline_worker_agent/startup/host_configuration_script.py
+++ b/src/deadline_worker_agent/startup/host_configuration_script.py
@@ -146,22 +146,29 @@ class HostConfigurationScriptRunner(ScriptRunnerBase):
         Run the host configuration script on posix.
         returns the exit code.
         """
-        # Now that we have a script, run it.
-        command = ["./host_configuration.sh"]
+        if sys.platform != "win32":
+            # Now that we have a script, run it.
+            command = ["./host_configuration.sh"]
 
-        self._action_event.clear()
-        self._run(command)
+            self._action_event.clear()
+            self._run(command)
 
-        # Wait for the completion event.
-        # Async callback prints out a message based on run state.
-        self._action_event.wait()
+            # Wait for the completion event.
+            # Async callback prints out a message based on run state.
+            self._action_event.wait()
 
-        if self._action_state is ActionState.SUCCESS and self.exit_code == 0:
-            return self.exit_code
-        else:
-            return self.exit_code if self.exit_code is not None else -1
+            if self._action_state is ActionState.SUCCESS and self.exit_code == 0:
+                return self.exit_code
+            else:
+                return self.exit_code if self.exit_code is not None else -1
+
+        assert False, "This method should never be run in Win32"
 
     def _run_win32(self, script_file_path: str) -> int:
+        """
+        Run the host configuration script on Windows.
+        returns the exit code.
+        """
         if sys.platform == "win32":
             win32_runner = _WindowsScriptRunner(
                 script_path=script_file_path,

--- a/src/deadline_worker_agent/windows/scripts/admin_script.ps1
+++ b/src/deadline_worker_agent/windows/scripts/admin_script.ps1
@@ -1,0 +1,28 @@
+param(
+    [string]$ScriptToRun,
+    [string]$LogFile,
+    [Parameter(ValueFromRemainingArguments=$true)]
+    [string[]]$RemainingArgs
+)
+
+$OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+# Set environment variables from remaining arguments
+foreach ($envVar in $RemainingArgs) {
+    if ($envVar -match '^(.+?)=(.*)$') {
+        $key = $matches[1]
+        $value = $matches[2]
+        if ($value -eq "NULL") {
+            Set-Item -Path "env:$key" -Value $null
+        } else {
+            Set-Item -Path "env:$key" -Value $value
+        }
+    }
+}
+
+# The actual script execution and logging
+. $ScriptToRun *>&1 | Out-File -FilePath $LogFile -Encoding utf8
+
+$exitCode = $LASTEXITCODE
+if ($null -eq $exitCode) { $exitCode = if ($?) { 0 } else { 1 } }
+exit $exitCode

--- a/src/deadline_worker_agent/windows/win_admin_runner.py
+++ b/src/deadline_worker_agent/windows/win_admin_runner.py
@@ -6,7 +6,7 @@ import sys
 
 assert sys.platform == "win32"
 from logging import Logger
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Optional
 import subprocess
 import win32com.shell.shell as shell
@@ -86,26 +86,37 @@ class _WindowsScriptRunner:
             return return_code
 
     def run_powershell(self, env_vars: Optional[dict[str, Optional[str]]]) -> int:
-        """Run powershell with the constructed script
-        Returns the process exit code.
+        """Run powershell with the specified script file
+        Args:
+            env_vars: Dictionary of environment variables where values can be None
+        Returns:
+            The process exit code.
         """
-
-        # Run Powershell, tell it to run a ps1 file and output all logs to the log file.
         executable = "powershell.exe"
+        wrapper_script = PureWindowsPath(__file__).parent / "scripts" / "admin_script.ps1"
+
+        # Convert environment variables to list of strings
+        env_var_list = []
+        if env_vars:
+            for key, value in env_vars.items():
+                if value is None:
+                    env_var_list.append(f"{key}=NULL")
+                else:
+                    env_var_list.append(f"{key}={value}")
+
         ps_command = [
             "-NoProfile",
             "-ExecutionPolicy",
             "Bypass",
-            "-Command",
-            f"""& {{
-                $OutputEncoding = [Console]::OutputEncoding = [System.Text.Encoding]::UTF8;
-                {self._prefix_environment_variables(env_vars)}
-                . '{self._script_path}' *>&1 | Out-File -FilePath '{self._logfile}' -Encoding utf8;
-                $exitCode = $LASTEXITCODE;
-                if ($null -eq $exitCode) {{ $exitCode = if ($?) {{ 0 }} else {{ 1 }} }};
-                exit $exitCode
-            }}""",
-        ]
+            "-File",
+            str(wrapper_script),
+            "-ScriptToRun",
+            self._script_path,
+            "-LogFile",
+            self._logfile,
+        ] + env_var_list
+
+
         command_line = subprocess.list2cmdline(ps_command)
         return self._run(executable=executable, command=command_line)
 
@@ -119,16 +130,3 @@ class _WindowsScriptRunner:
             file_path=Path(self._script_path),
             agent_user_permission=FileSystemPermissionEnum.FULL_CONTROL,
         )
-
-    @staticmethod
-    def _prefix_environment_variables(env_vars: Optional[dict[str, Optional[str]]]) -> str:
-        env_script = ""
-        if env_vars:
-            for key in env_vars.keys():
-                value = env_vars.get(key)
-                if value is not None:
-                    env_script += f"""$env:{key} = '{value}'\n"""
-                else:
-                    env_script += f"$env:{key} = $null\n"
-
-        return env_script

--- a/test/integ/startup/test_host_configuration.py
+++ b/test/integ/startup/test_host_configuration.py
@@ -285,8 +285,11 @@ Get-ChildItem env: | ForEach-Object { "$($_.Name)=$($_.Value)" }
         for log in expected_logs:
             assert any(log in m for m in messages)
 
-    def test_script_file_access(self, queue_handler: QueueHandler, tmp_path: Path):
-        """Tests the script file is only accessible by worker agent user."""
+    def test_script_and_log_file_access(self, queue_handler: QueueHandler, tmp_path: Path):
+        """
+        Tests the script file is only accessible by worker agent user.
+        On Windows, also check the log file is only accessible by worker agent user.
+        """
 
         # Given
         runner = self._create_host_configuration_script_runner(
@@ -309,10 +312,6 @@ Get-ChildItem env: | ForEach-Object { "$($_.Name)=$($_.Value)" }
             assert not mode & 0o002
             assert not mode & 0o001
         else:
-            import getpass
-            import win32con
-            import win32security
-            import ntsecuritycon
             from deadline_worker_agent.windows.win_admin_runner import _WindowsScriptRunner
 
             # Need to prepare the file permissions on Windows
@@ -323,51 +322,54 @@ Get-ChildItem env: | ForEach-Object { "$($_.Name)=$($_.Value)" }
             )
             win32_runner._prepare_file_permissions()
 
-            users_group_sid, _, _ = win32security.LookupAccountName(None, "Users")
-            current_user_sid, _, _ = win32security.LookupAccountName(None, getpass.getuser())
-            sd = win32security.GetFileSecurity(
-                str(script_file),
-                win32con.DACL_SECURITY_INFORMATION | win32con.OWNER_SECURITY_INFORMATION,
-            )
-            dacl = sd.GetSecurityDescriptorDacl()
+            # Test the script file
+            _windows_file_permissions_test(script_file)
+            # Test the log file
+            _windows_file_permissions_test(win32_runner._logfile)
 
-            users_group_permission_found: bool = False
-            administrator_group_permission_read_found: bool = False
-            administrator_group_permission_write_found: bool = False
 
-            if dacl is None:
-                assert False, "All users have access to the file."
+def _windows_file_permissions_test(file_path: str) -> None:
+    assert sys.platform == "win32"
+    import getpass
+    import win32con
+    import win32security
+    import ntsecuritycon
 
-            # Iterate through each ACE in the DACL
-            for i in range(dacl.GetAceCount()):
-                ace = dacl.GetAce(i)
-                (ace_type, ace_flags), ace_mask, sid = ace
+    users_group_sid, _, _ = win32security.LookupAccountName(None, "Users")
+    current_user_sid, _, _ = win32security.LookupAccountName(None, getpass.getuser())
+    sd = win32security.GetFileSecurity(
+        str(file_path),
+        win32con.DACL_SECURITY_INFORMATION | win32con.OWNER_SECURITY_INFORMATION,
+    )
+    dacl = sd.GetSecurityDescriptorDacl()
 
-                if sid == users_group_sid:
-                    # Check for read or write permission
-                    if (
-                        ace_mask & ntsecuritycon.FILE_GENERIC_READ
-                        == ntsecuritycon.FILE_GENERIC_READ
-                    ) or (
-                        ace_mask & ntsecuritycon.FILE_GENERIC_WRITE
-                        == ntsecuritycon.FILE_GENERIC_WRITE
-                    ):
-                        users_group_permission_found = True
-                elif sid == current_user_sid:
-                    # Check for read permission
-                    if (
-                        ace_mask & ntsecuritycon.FILE_GENERIC_READ
-                        == ntsecuritycon.FILE_GENERIC_READ
-                    ):
-                        administrator_group_permission_read_found = True
+    users_group_permission_found: bool = False
+    current_user_permission_read_found: bool = False
+    current_user_permission_write_found: bool = False
 
-                    # Check for write permission
-                    if (
-                        ace_mask & ntsecuritycon.FILE_GENERIC_WRITE
-                        == ntsecuritycon.FILE_GENERIC_WRITE
-                    ):
-                        administrator_group_permission_write_found = True
+    if dacl is None:
+        assert False, "All users have access to the file."
 
-            assert not users_group_permission_found
-            assert administrator_group_permission_read_found
-            assert administrator_group_permission_write_found
+    # Iterate through each ACE in the DACL
+    for i in range(dacl.GetAceCount()):
+        ace = dacl.GetAce(i)
+        (ace_type, ace_flags), ace_mask, sid = ace
+
+        if sid == users_group_sid:
+            # Check for read or write permission
+            if (ace_mask & ntsecuritycon.FILE_GENERIC_READ == ntsecuritycon.FILE_GENERIC_READ) or (
+                ace_mask & ntsecuritycon.FILE_GENERIC_WRITE == ntsecuritycon.FILE_GENERIC_WRITE
+            ):
+                users_group_permission_found = True
+        elif sid == current_user_sid:
+            # Check for read permission
+            if ace_mask & ntsecuritycon.FILE_GENERIC_READ == ntsecuritycon.FILE_GENERIC_READ:
+                current_user_permission_read_found = True
+
+            # Check for write permission
+            if ace_mask & ntsecuritycon.FILE_GENERIC_WRITE == ntsecuritycon.FILE_GENERIC_WRITE:
+                current_user_permission_write_found = True
+
+    assert not users_group_permission_found
+    assert current_user_permission_read_found
+    assert current_user_permission_write_found

--- a/test/unit/startup/test_entrypoint.py
+++ b/test/unit/startup/test_entrypoint.py
@@ -905,3 +905,4 @@ def test_fleet_host_config(
         ]
         assert len(all_args) > 0
         assert expected in all_args
+        sys_exit_mock.assert_called_once()


### PR DESCRIPTION
### What was the problem/requirement? (What/Why)
- From PR-601, a comment suggested not to construct the script inline with format strings, and instead create an embedded script file and run an embedded script file.

### What was the solution? (How)
- Migrate the existing script and argument formation to an embedded file. All format strings become arguments.
- Side note, some of this refactor was generated with Q AI

- The CLI that gets generated to run the script is something like this:
```
-NoProfile -ExecutionPolicy Bypass -File C:\Users\RDP\AppData\Local\hatch\env\virtual\deadline-cloud-worker-agent\W0BEOtIO\deadline-cloud-worker-agent\Lib\site-packages\deadline_worker_agent\windows\scripts\admin_script.ps1 -ScriptToRun C:\Users\RDP\test.ps1 -LogFile C:\Users\RDP\host.log -EnvVars DEADLINE_FARM_ID=farm-00000000000000000000000000000000 DEADLINE_FLEET_ID=fleet-00000000000000000000000000000000 ...
```

### What is the impact of this change?
- Better security ! Less chance for script injection attacks.

### How was this change tested?
- hatch build
- hatch run test
- hatch run integ-test
- hatch run e2e-test (windows, + new host config tests)

### Was this change documented?
- NA

### Is this a breaking change?
- No, the change is a drop-in replacement.
- 
----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*